### PR TITLE
Fix wrong prisma client path

### DIFF
--- a/src/components/pietanza-card.tsx
+++ b/src/components/pietanza-card.tsx
@@ -1,4 +1,4 @@
-import { Tag } from "@/generated/prisma";
+import { Tag } from "@/app/generated/prisma";
 import { ExtendedPietanza } from "@/lib/types";
 import { Card, Column, Media, Row, Text, Line, Icon, Tag as OnceTag } from "@/once-ui/components";
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '../generated/prisma'
+import { PrismaClient } from '../app/generated/prisma'
 
 
 const globalForPrisma = global as unknown as { 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { AreaCompetenza, Categoria, Pietanza, Tag } from "@/generated/prisma";
+import { AreaCompetenza, Categoria, Pietanza, Tag } from "@/app/generated/prisma";
 
 interface ExtendedTag extends Tag{}
 


### PR DESCRIPTION
## Summary
- fix import paths for generated prisma client

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a6530d7c8329a3c16caa55e78b6c