### PR TITLE
Add Jest setup with basic cache manager test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  testMatch: ['**/tests/**/*.test.ts'],
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build && prisma generate",
     "start": "next start",
     "biome-write": "npx @biomejs/biome format --write .",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@floating-ui/react-dom": "^2.1.1",
@@ -42,7 +43,10 @@
     "postcss-custom-media": "^10.0.7",
     "postcss-flexbugs-fixes": "^5.0.2",
     "prisma": "^6.9.0",
-    "typescript": "5.8.2"
+    "typescript": "5.8.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.12"
   },
   "overrides": {
     "@types/react": "19.0.1",

--- a/tests/cache-manager.test.ts
+++ b/tests/cache-manager.test.ts
@@ -1,0 +1,14 @@
+import { getMenuFromCache, setMenuInCache, invalidateCache } from '../src/lib/cache-manager';
+
+describe('cache manager', () => {
+  afterEach(async () => {
+    await invalidateCache();
+  });
+
+  it('stores and retrieves menu data', async () => {
+    const sample = { id: 'test', name: 'Sample menu' } as any;
+    await setMenuInCache('1', 'en', sample);
+    const result = await getMenuFromCache('1', 'en');
+    expect(result).toEqual(sample);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest configuration and sample test
- create cache-manager test verifying caching works
- add Jest dev dependencies and test script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a80165e08329b2e2ceebb5cd532d