### PR TITLE
Fix import path in cache-manager

### DIFF
--- a/src/lib/cache-manager.ts
+++ b/src/lib/cache-manager.ts
@@ -1,5 +1,5 @@
 "use server";
-import { ExtendedAreaCompetenza } from '@/lib/utils';
+import { ExtendedAreaCompetenza } from '@/lib/types';
 import { LRUCache } from 'lru-cache';
 
 const CACHE_TTL = 1000 * 60 * 5; 


### PR DESCRIPTION
## Summary
- fix import path for `ExtendedAreaCompetenza` in `cache-manager`

## Testing
- `npx tsc --noEmit` *(fails: Type 'ExtendedAreaCompetenza' does not satisfy the constraint '{}')*

------
https://chatgpt.com/codex/tasks/task_e_6844a7fd99dc832980e68742efc50eef