### PR TITLE
Implement multilingual landing page

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -12,6 +12,11 @@ export const config = {
 export function middleware(req: NextRequest) {
   // Ignore paths with "icon" or "chrome"
   if (req.nextUrl.pathname.indexOf('icon') > -1 || req.nextUrl.pathname.indexOf('chrome') > -1) return NextResponse.next()
+
+  const pathname = req.nextUrl.pathname
+  if (pathname === '/prenota' || languages.some(l => pathname === `/${l}/prenota`)) {
+    return NextResponse.redirect('https://alterrazzo.plateform.app')
+  }
   
   let lng
   // Try to get language from cookie

--- a/src/app/[lng]/about-us/page.tsx
+++ b/src/app/[lng]/about-us/page.tsx
@@ -1,0 +1,12 @@
+import { Column, Text } from "@/once-ui/components";
+import { getT } from "../../i18n";
+
+export default async function AboutPage() {
+  const { t } = await getT('translation');
+  return (
+    <Column padding="8" gap="8">
+      <Text variant="heading-default-m">{t('home_chi_siamo_title')}</Text>
+      <Text variant="body-default-s">{t('home_chi_siamo_text')}</Text>
+    </Column>
+  );
+}

--- a/src/app/[lng]/menu/page.tsx
+++ b/src/app/[lng]/menu/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+import React, { useState, useEffect } from "react";
+import { Flex } from "@/once-ui/components";
+import { useT } from "../../i18n/client";
+
+export default function MenuHome() {
+  const { t } = useT('translation');
+  const [menu, setMenu] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchMenu = async () => {
+      const response = await fetch('/api/areaCompetenza/');
+      const data = await response.json();
+      setMenu(data);
+    };
+    fetchMenu();
+    setLoading(false);
+  }, []);
+
+  return (
+    <Flex>
+      {loading ? (
+        <div>Loading...</div>
+      ) : (
+        menu?.map((item, index) => (
+          <div key={index}>
+            <h1>{item.descrizione}</h1>
+          </div>
+        ))
+      )}
+    </Flex>
+  );
+}

--- a/src/app/[lng]/page.tsx
+++ b/src/app/[lng]/page.tsx
@@ -1,35 +1,71 @@
-"use client";
+import { Button, Column, Logo, Media, Row, Text } from "@/once-ui/components";
+import { getT } from "../i18n";
 
-import React, { useState, useEffect, forwardRef } from "react";
-import classNames from "classnames";
-import { Flex } from "@/once-ui/components";
-import { useT } from "../i18n/client";
+export default async function Home() {
+  const { t } = await getT("translation");
+  return (
+    <Column as="main" fillWidth gap="48" horizontal="center">
+      <Column
+        as="section"
+        paddingY="48"
+        gap="12"
+        horizontal="center"
+        vertical="center"
+        fillWidth
+        style={{
+          minHeight: "100vh",
+          backgroundImage:
+            'linear-gradient(rgba(0,0,0,0.5), rgba(0,0,0,0.5)), url("/images/hero.jpg")',
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      >
+        <Logo size="l" wordmark />
+        <Text variant="display-strong-m" align="center">
+          {t("home_hero_tagline")}
+        </Text>
+        <Row gap="4" horizontal="center">
+          <Button href="prenota">{t("home_hero_book")}</Button>
+          <Button variant="secondary" href="menu">
+            {t("home_hero_menu")}
+          </Button>
+        </Row>
+      </Column>
 
-export default function Home() {
-    const { t } = useT('translation');
-    const [menu, setMenu] = useState<any[]>([]); // Using empty array as initial value
-    const [loading, setLoading] = useState(true);
-    useEffect(() => {
-        const fetchMenu = async () => {
-            const response = await fetch('/api/areaCompetenza/');
-            const data = await response.json();
-            setMenu(data); // data is already an array from the API
-        };
-        fetchMenu();
-        setLoading(false);
-    }, []);
-    return (
-        <Flex>
-            {loading ? (
-                <div>Loading...</div>
-            ) : (
-                menu?.map((item, index) => (
-                    <div key={index}>
-                        <h1>{item.descrizione}</h1>
-                        
-                    </div>
-                ))
-            )}
-        </Flex>
-    )
+      <Column as="section" padding="20" gap="8" maxWidth="s" horizontal="center">
+        <Text align="center" variant="body-default-m">
+          {t("home_intro_p1")}
+        </Text>
+        <Text align="center" variant="body-default-m">
+          {t("home_intro_p2")}
+        </Text>
+      </Column>
+
+      <Column as="section" gap="8" maxWidth="m" horizontal="center">
+        <Media src="/images/hero.jpg" alt={t("home_chi_siamo_title")} height={24} radius="l" />
+        <Column padding="12" gap="4" horizontal="center">
+          <Text variant="heading-default-m" align="center">
+            {t("home_chi_siamo_title")}
+          </Text>
+          <Text variant="body-default-s" align="center">
+            {t("home_chi_siamo_text")}
+          </Text>
+          <Button href="about-us">{t("home_chi_siamo_cta")}</Button>
+        </Column>
+      </Column>
+
+      <Column as="section" gap="8" maxWidth="m" horizontal="center">
+        <Media src="/images/demo.jpg" alt={t("home_filosofia_title")} height={24} radius="l" />
+        <Column padding="12" gap="4" horizontal="center">
+          <Text variant="heading-default-m" align="center">
+            {t("home_filosofia_title")}
+          </Text>
+          <Text variant="body-default-s" align="center">
+            {t("home_filosofia_text")}
+          </Text>
+          <Button href="menu">{t("home_filosofia_cta")}</Button>
+        </Column>
+      </Column>
+    </Column>
+  );
 }

--- a/src/app/i18n/locales/en/translation.json
+++ b/src/app/i18n/locales/en/translation.json
@@ -23,5 +23,16 @@
   },
   "cerca-pietanze": "Search...",
   "seleziona-menu": "Select a menu",
-  "dettagli": "Details"
+  "dettagli": "Details",
+  "home_hero_tagline": "Restaurant and pizzeria in Gambarie",
+  "home_hero_book": "Book a table",
+  "home_hero_menu": "View the menu",
+  "home_intro_p1": "Al Terrazzo is open to those seeking relaxation, fun and good cuisine. Enjoy the scenery of Aspromonte that tells years of history, tranquility and beauty. You will love our land, the warmth and the flavor of the mountains. You will love the hearts of those who live and work here, create, invent and share.",
+  "home_intro_p2": "Through our dishes we share with you our passion for traditional ingredients, for good food and drink, and for good breaks in company.",
+  "home_chi_siamo_title": "Who we are",
+  "home_chi_siamo_text": "A family who with care, passion and dedication has been offering you the best flavors of traditional Calabrian cuisine for over 20 years. The restaurant is the result of the dream of Mimmo and his wife Agnieszka, known as Aga, who created the ideal place to relax and enjoy good Calabrian food in one of the most picturesque areas of the center of Gambarie d’Aspromonte. All of us in the Al Terrazzo family welcome you by conveying the commitment, research and love we put into our food and wine offer, never forgetting the smile with which we greet you in our restaurant in Gambarie.",
+  "home_chi_siamo_cta": "Learn about us",
+  "home_filosofia_title": "Our kitchen philosophy",
+  "home_filosofia_text": "Freshness, quality and seasonality of ingredients are the three fundamental principles that accompany our idea of cooking. The kitchen is Aga’s realm; she personally chooses, for the restaurant and the pizzeria, ingredients from the best producers, preferring those of the territory. The dishes tell the story of the land and of the traditional Aspromonte cuisine, with special attention to celiacs. We offer dishes based on vegetables, mushrooms, wild boar, homemade pasta, aromas and fruits that we pick from our garden.",
+  "home_filosofia_cta": "See menu and book"
 }

--- a/src/app/i18n/locales/it/translation.json
+++ b/src/app/i18n/locales/it/translation.json
@@ -23,5 +23,16 @@
   },
   "cerca-pietanze": "Cerca pietanze...",
   "seleziona-menu": "Seleziona un menu",
-  "dettagli": "Dettagli"
+  "dettagli": "Dettagli",
+  "home_hero_tagline": "Ristorante e pizzeria a Gambarie",
+  "home_hero_book": "Prenota un tavolo",
+  "home_hero_menu": "Guarda il menù",
+  "home_intro_p1": "Al Terrazzo è aperto a chi cerca relax, divertimento e la buona cucina. Goditi il paesaggio dell’Aspromonte che racconta anni di storia, di quiete, di bellezza. Amerai la nostra terra, il calore e il sapore della montagna. Amerai il cuore di quanti qui vivono e lavorano, creano, inventano e condividono.",
+  "home_intro_p2": "Attraverso i nostri piatti condividiamo con te la nostra passione per gli ingredienti della tradizione, per il buon mangiare e il buon bere, e per le buone pause in compagnia.",
+  "home_chi_siamo_title": "Chi siamo",
+  "home_chi_siamo_text": "Una famiglia che con cura, passione e dedizione, da oltre 20 anni, ti offre i migliori sapori della cucina tipica calabrese.Il ristorante è il risultato del sogno di Mimmo e della moglie Agnieszka, per gli amici Aga, che hanno creato il  luogo ideale dove rilassarsi e gustare la buona cucina calabrese in una delle aree più suggestive del centro di Gambarie d’Aspromonte. Tutti noi della famiglia de Al Terrazzo ti accogliamo trasmettendo l’impegno, la ricerca e l’amore che mettiamo nella nostra offerta eno-gastronomica, senza mai dimenticare il sorriso con cui ti accogliamo nel nostro ristorante a Gambarie.",
+  "home_chi_siamo_cta": "Scopri chi siamo",
+  "home_filosofia_title": "La filosofia in cucina",
+  "home_filosofia_text": "Freschezza, qualità e stagionalità delle materie prime sono i tre principi cardine che accompagnano la nostra idea di cucina. La cucina è il regno di Aga, che sceglie personalmente, per il ristorante e la pizzeria, gli ingredienti dai migliori produttori, prediligendo quelli del territorio. I piatti raccontano il territorio e la cucina tradizionale aspromontana, con una particolare attenzione anche per i celiaci. Ti offriamo pietanze a base di ortaggi, funghi, cinghiale, pasta fatta in casa, profumi e frutti che raccogliamo dal nostro orto.",
+  "home_filosofia_cta": "Scopri menu e prenota"
 }


### PR DESCRIPTION
## Summary
- create dynamic home page with multiple hero sections
- add about-us and menu routes
- redirect `/prenota` via middleware
- localize new home page content in Italian and English
- refine home page layout following UI/UX best practices
- make hero fullscreen with centered content

## Testing
- `npm test` *(fails: jest not found)*
- `npx biome check src/app/[lng]/page.tsx` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844afa00f50832986944dc9f06a22b5